### PR TITLE
fix: Do not ignore environment variable `TOXENV` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ COVERAGE_TEST_RCFILE = $(CURDIR)/.coveragerc.test.ini
 COVERAGE_TEST_DATA_FILE = $(CURDIR)/.test.coverage
 
 # Tox
-TOXENV = py38
+TOXENV ?= py38
 TOX_WORK_DIR = $(CURDIR)/.tox
 
 # Test Reports


### PR DESCRIPTION
Ref: https://cordada.aha.io/requirements/COMPCLDATA-100-5
Ref: https://cordada.aha.io/features/COMPCLDATA-100