### PR TITLE
Enable Python dependency sync check for Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,10 +125,11 @@ jobs:
           make test-coverage-report
 
       - name: Check that compiled Python dependency manifests are up-to-date with their sources
+        # FIXME: There are issues related to testing with multiple Python versions.
+        if: ${{ startsWith(matrix.python_version, '3.8.') }}
         run: |
           source "$PYTHON_VIRTUALENV_ACTIVATE"
-          # FIXME: `make python-deps-sync-check` fails when executed with different Python version.
-          make --ignore-errors python-deps-sync-check
+          make python-deps-sync-check
 
       - name: Store Artifacts
         if: ${{ always() }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -43,7 +43,9 @@ flake8-formatter-junit-xml==0.0.6
 idna==3.3
     # via requests
 importlib-metadata==4.12.0
-    # via twine
+    # via
+    #   keyring
+    #   twine
 ipython==7.34.0
     # via -r requirements-dev.in
 isort==5.10.1
@@ -126,6 +128,11 @@ six==1.16.0
     #   bleach
     #   junit-xml
     #   tox
+tomli==2.0.1
+    # via
+    #   black
+    #   mypy
+    #   tox
 tox==3.27.1
     # via -r requirements-dev.in
 traitlets==5.3.0
@@ -135,7 +142,10 @@ traitlets==5.3.0
 twine==4.0.2
     # via -r requirements-dev.in
 typing-extensions==4.3.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
+    #   rich
 unittest-xml-reporting==3.2.0
     # via -r requirements-dev.in
 urllib3==1.26.11


### PR DESCRIPTION
- chore: Enable Python dependency sync check for Python 3.8.
- chore: Recompile Python dependency manifests with Python 3.8.