### PR TITLE
Improve Super-Linter GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,20 +137,10 @@ jobs:
           path: test_reports/
           if-no-files-found: warn
 
-  super-linter:
-    name: Super-Linter
-    uses: cordada/github-actions-utils/.github/workflows/super-linter.yaml@master
-    with:
-      default_git_branch: develop
-
-      validate_editorconfig: true
-      validate_markdown: true
-
   post-test:
     name: Post-Test
     needs:
       - test
-      - super-linter
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -1,0 +1,36 @@
+# GitHub Actions Workflow for Super-Linter
+#
+# Super-Linter is a simple combination of various linters, written in bash, to help validate your
+# source code.
+#
+# - Web site: https://github.com/github/super-linter/
+# - Documentation: https://github.com/github/super-linter#readme
+
+name: Super-Linter
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  statuses: write
+  checks: write
+
+jobs:
+  super-linter:
+    name: Super-Linter
+    uses: cordada/github-actions-utils/.github/workflows/super-linter.yaml@master
+    with:
+      default_git_branch: develop
+      validate_all_codebase: false
+
+      validate_editorconfig: true
+      validate_markdown: true


### PR DESCRIPTION
- Move Super-Linter from CI workflow to its own workflow.
- Configure Super-Linter to validate only new and changed files.
- Only run Super-Linter workflow on pull requests and pushes to main branches.