### PR TITLE
Get PyPI username from GitHub Actions variable instead of secret

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,6 +53,6 @@ jobs:
             TWINE_USERNAME="${PYPI_USERNAME:?}" \
             TWINE_PASSWORD="${PYPI_PASSWORD:?}"
         env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_USERNAME: ${{ vars.PYPI_USERNAME }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
           TWINE_NON_INTERACTIVE: "true"


### PR DESCRIPTION
The PyPI username is not sensitive information, so it does not need to be a secret.