### PR TITLE
Fix deprecation of GitHub Actions `set-output`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
             python -c 'import sys; v = sys.version_info; print("py{}{}".format(v.major, v.minor))'
           )
 
-          echo "::set-output name=tox_env::${tox_env:?}"
+          echo "tox_env=${tox_env:?}" >> "$GITHUB_OUTPUT"
 
       - name: Test
         run: |


### PR DESCRIPTION
> The `set-output` command is deprecated and will be disabled soon.
> Please upgrade to using Environment Files. For more information see:
> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/