### PR TITLE
Pin versions of actions used in GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,13 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore:"
+    labels:
+      - dependencies
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set Up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "${{ matrix.python_version }}"
 
@@ -47,7 +47,7 @@ jobs:
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.5
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
@@ -77,15 +77,15 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set Up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "${{ matrix.python_version }}"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.5
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: Store Artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: test_reports_${{ matrix.python_version }}
           path: test_reports/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,21 +27,21 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set Up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.10.9"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.5
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
 
       - name: Restore Artifacts (Release)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: release
           path: ${{ inputs.artifacts_path }}/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set Up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.10.9"
 
@@ -46,7 +46,7 @@ jobs:
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.5
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
@@ -67,7 +67,7 @@ jobs:
           make dist
 
       - name: Store Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: release
           path: ${{ env.ARTIFACTS_PATH }}/


### PR DESCRIPTION
- chore: Pin versions of actions used in GitHub Actions workflows.
- chore: Add GitHub Actions to Dependabot configuration.