### PR TITLE
Release 1.3.1

### DIFF
--- a/.coveragerc.test.ini
+++ b/.coveragerc.test.ini
@@ -14,5 +14,8 @@ branch = True
 [report]
 show_missing = True
 
+[xml]
+output = test_reports/coverage/xml/coverage.xml
+
 [html]
 directory = test_reports/coverage/html

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       prefix: "chore:"
     labels:
       - dependencies
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -16,7 +16,7 @@ jobs:
   # -----BEGIN Workflow Configuration Job-----
   workflow_config:
     name: Workflow Configuration
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     outputs:
       PRODUCTION_VCS_REF: ${{ env.PRODUCTION_VCS_REF }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Set Up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v4.5.0
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Set Up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v4.5.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.6
+        uses: actions/cache@v3.3.1
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
@@ -83,7 +83,7 @@ jobs:
           python-version: "${{ matrix.python_version }}"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.6
+        uses: actions/cache@v3.3.1
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.5
+        uses: actions/cache@v3.2.6
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
@@ -83,7 +83,7 @@ jobs:
           python-version: "${{ matrix.python_version }}"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.5
+        uses: actions/cache@v3.2.6
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   pre-build:
     name: Pre-Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - run: "true"
@@ -23,7 +23,7 @@ jobs:
     name: Build
     needs:
       - pre-build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
     name: Test
     needs:
       - build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -139,7 +139,7 @@ jobs:
     name: Post-Test
     needs:
       - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - run: "true"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,12 @@ jobs:
           source "$PYTHON_VIRTUALENV_ACTIVATE"
           make test-coverage-report
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3.1.2
+        with:
+          directory: ./test_reports/coverage/
+          fail_ci_if_error: true
+
       - name: Check that compiled Python dependency manifests are up-to-date with their sources
         # FIXME: There are issues related to testing with multiple Python versions.
         if: ${{ startsWith(matrix.python_version, '3.8.') }}

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v3.0.4

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3.0.3
+        uses: actions/dependency-review-action@v3.0.4
         with:
           fail-on-severity: critical

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.10.9"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.5
+        uses: actions/cache@v3.2.6
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.10.9"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.6
+        uses: actions/cache@v3.3.1
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: ${{ inputs.deploy_env }}
 
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Set Up Python
         id: set_up_python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Set Up Python
         id: set_up_python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.5
+        uses: actions/cache@v3.2.6
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3.2.6
+        uses: actions/cache@v3.3.1
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.3.1 (2023-06-09)
+
+- (PR #68, 2023-03-13) chore: bump mypy from 0.991 to 1.0.1
+- (PR #71, 2023-03-13) chore: bump actions/cache from 3.2.5 to 3.2.6
+- (PR #74, 2023-03-14) chore: bump tox from 4.4.5 to 4.4.7
+- (PR #72, 2023-03-14) chore: bump coverage from 7.1.0 to 7.2.1
+- (PR #76, 2023-03-29) Decrease Dependabot's open pull request limit to 5
+- (PR #75, 2023-03-30) Update GitHub Actions Linux runner to Ubuntu 22.04
+- (PR #85, 2023-04-05) Update code owners for Python dependencies
+- (PR #82, 2023-04-05) chore(deps): Bump black from 23.1.0 to 23.3.0
+- (PR #79, 2023-04-14) chore: bump actions/dependency-review-action from 3.0.3 to 3.0.4
+- (PR #77, 2023-04-14) chore: bump actions/cache from 3.2.6 to 3.3.1
+- (PR #83, 2023-04-17) chore: bump mypy from 1.0.1 to 1.1.1
+- (PR #57, 2023-04-26) chore(deps): Bump ipython from 7.34.0 to 8.10.0
+- (PR #87, 2023-05-05) chore: bump actions/checkout from 3.3.0 to 3.5.2
+- (PR #94, 2023-05-15) chore: Bump coverage from 7.2.1 to 7.2.5
+- (PR #93, 2023-05-16) chore: Bump tox from 4.4.7 to 4.5.1
+- (PR #98, 2023-05-26) Add Codecov to CI workflow
+
+
 ## 1.3.0 (2023-02-27)
 
 - (PR #44, 2023-02-08) chore: bump tox from 3.27.1 to 4.4.4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,7 @@
 
 # Default
 * @cordada/developers
+
+# Dependencies
+/requirements.*
+/requirements-*.*

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ test-coverage-report: export COVERAGE_RCFILE = $(COVERAGE_TEST_RCFILE)
 test-coverage-report: export COVERAGE_FILE = $(COVERAGE_TEST_DATA_FILE)
 test-coverage-report: ## Run tests, measure code coverage, and generate reports
 	$(COVERAGE) report
+	$(COVERAGE) xml
 	$(COVERAGE) html
 
 .PHONY: deploy

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Tributaria* (SUNAT) of *Perú*.
 | [![Maintainability](https://api.codeclimate.com/v1/badges/ede6619f0d7dc4a0f0bc/maintainability)](https://codeclimate.com/github/cordada/lib-pe-sunat-python/maintainability) | [Open Source Insights](https://deps.dev/pypi/pe-sunat) |
 
 
+| Code Coverage |
+| ------------- |
+| [![Codecov](https://codecov.io/gh/cordada/lib-pe-sunat-python/branch/develop/graph/badge.svg?token=T4NJV2PI6X)](https://codecov.io/gh/cordada/lib-pe-sunat-python) |
+
+
 ### Hosting
 
 | Deployment Environment | Python Package Registry |

--- a/cordada/pe_sunat/__init__.py
+++ b/cordada/pe_sunat/__init__.py
@@ -2,4 +2,4 @@
 PE-SUNAT Python Library
 """
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,7 +8,7 @@ black==23.3.0
 coverage==7.2.1
 flake8-formatter-junit-xml==0.0.6
 flake8==6.0.0
-ipython==7.34.0
+ipython==8.10.0
 isort==5.12.0
 mypy==1.1.1
 tox==4.4.7

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,7 +10,7 @@ flake8-formatter-junit-xml==0.0.6
 flake8==6.0.0
 ipython==7.34.0
 isort==5.12.0
-mypy==1.0.1
+mypy==1.1.1
 tox==4.4.7
 twine==4.0.2
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,7 +4,7 @@
 
 -c requirements.txt
 
-black==23.1.0
+black==23.3.0
 coverage==7.2.1
 flake8-formatter-junit-xml==0.0.6
 flake8==6.0.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,6 +11,6 @@ flake8==6.0.0
 ipython==7.34.0
 isort==5.12.0
 mypy==1.0.1
-tox==4.4.5
+tox==4.4.7
 twine==4.0.2
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@
 -c requirements.txt
 
 black==23.1.0
-coverage==7.1.0
+coverage==7.2.1
 flake8-formatter-junit-xml==0.0.6
 flake8==6.0.0
 ipython==7.34.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@
 -c requirements.txt
 
 black==23.3.0
-coverage==7.2.1
+coverage==7.2.5
 flake8-formatter-junit-xml==0.0.6
 flake8==6.0.0
 ipython==8.10.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,6 +11,6 @@ flake8==6.0.0
 ipython==8.10.0
 isort==5.12.0
 mypy==1.1.1
-tox==4.4.7
+tox==4.5.1
 twine==4.0.2
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,7 +10,7 @@ flake8-formatter-junit-xml==0.0.6
 flake8==6.0.0
 ipython==7.34.0
 isort==5.12.0
-mypy==0.991
+mypy==1.0.1
 tox==4.4.5
 twine==4.0.2
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 backcall==0.2.0
     # via ipython
-black==23.1.0
+black==23.3.0
     # via -r requirements-dev.in
 bleach==5.0.1
     # via readme-renderer

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,7 +72,7 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.7.0
     # via flake8
-mypy==0.991
+mypy==1.0.1
     # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ colorama==0.4.6
     # via tox
 commonmark==0.9.1
     # via rich
-coverage==7.1.0
+coverage==7.2.1
     # via -r requirements-dev.in
 cryptography==39.0.1
     # via secretstorage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -141,7 +141,7 @@ tomli==2.0.1
     #   mypy
     #   pyproject-api
     #   tox
-tox==4.4.5
+tox==4.4.7
     # via -r requirements-dev.in
 traitlets==5.3.0
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via tox
 commonmark==0.9.1
     # via rich
-coverage==7.2.1
+coverage==7.2.5
     # via -r requirements-dev.in
 cryptography==39.0.1
     # via secretstorage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,7 +40,7 @@ docutils==0.19
     # via readme-renderer
 executing==1.2.0
     # via stack-data
-filelock==3.9.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
@@ -82,7 +82,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-packaging==23.0
+packaging==23.1
     # via
     #   black
     #   pyproject-api
@@ -97,7 +97,7 @@ pickleshare==0.7.5
     # via ipython
 pkginfo==1.8.3
     # via twine
-platformdirs==2.6.2
+platformdirs==3.5.0
     # via
     #   black
     #   tox
@@ -121,7 +121,7 @@ pygments==2.12.0
     #   ipython
     #   readme-renderer
     #   rich
-pyproject-api==1.5.0
+pyproject-api==1.5.1
     # via tox
 readme-renderer==35.0
     # via twine
@@ -150,7 +150,7 @@ tomli==2.0.1
     #   mypy
     #   pyproject-api
     #   tox
-tox==4.4.7
+tox==4.5.1
     # via -r requirements-dev.in
 traitlets==5.3.0
     # via
@@ -169,7 +169,7 @@ urllib3==1.26.11
     # via
     #   requests
     #   twine
-virtualenv==20.17.1
+virtualenv==20.23.0
     # via tox
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --strip-extras requirements-dev.in
 #
+asttokens==2.2.1
+    # via stack-data
 backcall==0.2.0
     # via ipython
 black==23.3.0
@@ -36,6 +38,8 @@ distlib==0.3.6
     # via virtualenv
 docutils==0.19
     # via readme-renderer
+executing==1.2.0
+    # via stack-data
 filelock==3.9.0
     # via
     #   tox
@@ -52,7 +56,7 @@ importlib-metadata==4.12.0
     # via
     #   keyring
     #   twine
-ipython==7.34.0
+ipython==8.10.0
     # via -r requirements-dev.in
 isort==5.12.0
     # via -r requirements-dev.in
@@ -104,6 +108,8 @@ prompt-toolkit==3.0.30
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
+pure-eval==0.2.2
+    # via stack-data
 pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
@@ -133,8 +139,11 @@ secretstorage==3.3.2
     # via keyring
 six==1.16.0
     # via
+    #   asttokens
     #   bleach
     #   junit-xml
+stack-data==0.6.2
+    # via ipython
 tomli==2.0.1
     # via
     #   black
@@ -168,6 +177,3 @@ webencodings==0.5.1
     # via bleach
 zipp==3.8.1
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,9 +72,9 @@ matplotlib-inline==0.1.3
     # via ipython
 mccabe==0.7.0
     # via flake8
-mypy==1.0.1
+mypy==1.1.1
     # via -r requirements-dev.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy


### PR DESCRIPTION
## Changes

- (PR #68, 2023-03-13) chore: bump mypy from 0.991 to 1.0.1
- (PR #71, 2023-03-13) chore: bump actions/cache from 3.2.5 to 3.2.6
- (PR #74, 2023-03-14) chore: bump tox from 4.4.5 to 4.4.7
- (PR #72, 2023-03-14) chore: bump coverage from 7.1.0 to 7.2.1
- (PR #76, 2023-03-29) Decrease Dependabot's open pull request limit to 5
- (PR #75, 2023-03-30) Update GitHub Actions Linux runner to Ubuntu 22.04
- (PR #85, 2023-04-05) Update code owners for Python dependencies
- (PR #82, 2023-04-05) chore(deps): Bump black from 23.1.0 to 23.3.0
- (PR #79, 2023-04-14) chore: bump actions/dependency-review-action from 3.0.3 to 3.0.4
- (PR #77, 2023-04-14) chore: bump actions/cache from 3.2.6 to 3.3.1
- (PR #83, 2023-04-17) chore: bump mypy from 1.0.1 to 1.1.1
- (PR #57, 2023-04-26) chore(deps): Bump ipython from 7.34.0 to 8.10.0
- (PR #87, 2023-05-05) chore: bump actions/checkout from 3.3.0 to 3.5.2
- (PR #94, 2023-05-15) chore: Bump coverage from 7.2.1 to 7.2.5
- (PR #93, 2023-05-16) chore: Bump tox from 4.4.7 to 4.5.1
- (PR #98, 2023-05-26) Add Codecov to CI workflow