### PR TITLE
Improve CI/CD workflows

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PRODUCTION_VCS_REF: refs/heads/master # Keep in sync with the branch list in `jobs.release.if`.
   STAGING_VCS_REF: refs/heads/develop # Keep in sync with the branch list in `jobs.release.if`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ matrix.python_version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
+          fail-on-cache-miss: true
 
       - name: Set Tox Environment
         id: set_tox_environment

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     name: Dependency Review

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
+          fail-on-cache-miss: true
 
       - name: Restore Artifacts (Release)
         uses: actions/download-artifact@v3.0.2

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   git-commit-lint:
     name: Git Commit Linter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           path: ".pyenv"
           key: py-v1-deps-${{ runner.os }}-${{ steps.set_up_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('Makefile', 'make/**.mk') }}
+          fail-on-cache-miss: true
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -24,6 +24,10 @@ permissions:
   statuses: write
   checks: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   super-linter:
     name: Super-Linter


### PR DESCRIPTION
- For jobs that require a cache entry to exist, fail the workflow if the cache entry is not found by setting `fail-on-cache-miss` to `true`.
- Auto-cancel redundant GitHub Actions jobs. Related documentation: https://docs.github.com/en/actions/using-jobs/using-concurrency