### PR TITLE
Replace hardcoded versions of Pip and others in Make variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,23 @@ SOURCES_ROOT = $(CURDIR)/src
 # Python
 PYTHON = python3
 PYTHON_PIP = $(PYTHON) -m pip
-PYTHON_PIP_VERSION_SPECIFIER = ==23.1.2
-PYTHON_SETUPTOOLS_VERSION_SPECIFIER = ~=59.4.0
-PYTHON_WHEEL_VERSION_SPECIFIER = ~=0.37.1
+PYTHON_PIP_VERSION_SPECIFIER = $(shell \
+	grep -E '^pip==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
+	| head -n 1 | sed 's/^pip//' \
+)
+PYTHON_SETUPTOOLS_VERSION_SPECIFIER = $(shell \
+	grep -E '^setuptools==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
+	| head -n 1 | sed 's/^setuptools//' \
+)
+PYTHON_WHEEL_VERSION_SPECIFIER = $(shell \
+	grep -E '^wheel==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
+	| head -n 1 | sed 's/^wheel//' \
+)
 PYTHON_VIRTUALENV_DIR = lib-pe-sunat.pyenv
-PYTHON_PIP_TOOLS_VERSION_SPECIFIER = ==7.3.0
+PYTHON_PIP_TOOLS_VERSION_SPECIFIER = $(shell \
+	grep -E '^pip-tools==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
+	| head -n 1 | sed 's/^pip-tools//' \
+)
 PYTHON_PIP_TOOLS_SRC_FILES = requirements.in requirements-dev.in
 
 # Black


### PR DESCRIPTION
In `Makefile`, obtain the versions of `pip`, `setuptools`, `wheel`, and `pip-tools` from Python dependency manifests instead of hardcoding them in `Makefile`.

This change avoids having to update the versions of those packages in multiple places (`requirements.*` and `Makefile`).