### PR TITLE
Move Python version requirement to Python Project Configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
         id: set_up_python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: "3.10"
+          python-version-file: "pyproject.toml"
 
       - name: Restoring/Saving Cache
         uses: actions/cache@v4.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         id: set_up_python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: "3.10"
+          python-version-file: "pyproject.toml"
 
       - name: Create Python Virtual Environment
         run: make python-virtualenv PYTHON_VIRTUALENV_DIR=".pyenv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 name = "pe-sunat"
 # version = ""
 dependencies = []
-# requires-python = ">=3.8"
+requires-python = ">=3.8"
 authors = [
   {name = "Cordada SpA", email = "no-reply@cordada.com"},
 ]
@@ -39,7 +39,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
 ]
-dynamic = ["version", "requires-python"]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 from setuptools import setup
 
 
-setup(python_requires='>=3.8')
+setup()


### PR DESCRIPTION
- Move Python runtime version requirement from Setuptools Configuration (`python_requires` in `setup.py`) to Python Project Configuration (`requires-python` in `pyproject.toml`).
- Dependabot previously determined the Python version by parsing `setup.py`; now it should be able to determine that by parsing the compiled Python requirements files (`requirements*.txt`). See: https://github.com/dependabot/dependabot-core/commit/5a7d5db9d563116348cda1d85fbc48d7b546a2be
- Update CI/CD workflows to obtain Python version from file `pyproject.toml` instead of hardcoding it in the workflow.