### PR TITLE
deps: Update `cryptography` from 43.0.1 to 44.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ commonmark==0.9.1
     # via rich
 coverage==7.6.1
     # via -r requirements-dev.in
-cryptography==43.0.1
+cryptography==44.0.1
     # via secretstorage
 distlib==0.3.7
     # via virtualenv


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/cryptography/44.0.1/)
- ~~[Release Notes]()~~
- [Changelog](https://cryptography.io/en/44.0.1/changelog/#v44-0-1) [Changelog](https://github.com/pyca/cryptography/blob/44.0.1/CHANGELOG.rst#4401---2025-02-11)
- [Commits](https://github.com/pyca/cryptography/compare/43.0.1...44.0.1)

Fixes: https://github.com/cordada/lib-pe-sunat-python/security/dependabot/30