### PR TITLE
deps: Uninstall Python package `wheel`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,6 @@ PYTHON_SETUPTOOLS_VERSION_SPECIFIER = $(shell \
 	grep -E '^setuptools==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
 	| head -n 1 | sed 's/^setuptools//' \
 )
-PYTHON_WHEEL_VERSION_SPECIFIER = $(shell \
-	grep -E '^wheel==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
-	| head -n 1 | sed 's/^wheel//' \
-)
 PYTHON_VIRTUALENV_DIR = lib-pe-sunat.pyenv
 PYTHON_PIP_TOOLS_VERSION_SPECIFIER = $(shell \
 	grep -E '^pip-tools==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
@@ -93,7 +89,7 @@ install-dev: ## Install for development
 	$(PYTHON_PIP) check
 
 .PHONY: install-deps
-install-deps: python-pip-install python-setuptools-install python-wheel-install
+install-deps: python-pip-install python-setuptools-install
 install-deps: ## Install dependencies
 	$(PYTHON_PIP) install -r requirements.txt
 	$(PYTHON_PIP) check

--- a/make/python.mk
+++ b/make/python.mk
@@ -3,7 +3,6 @@ PYTHON_PIP ?= $(PYTHON) -m pip
 PYTHON_VIRTUALENV_DIR ?= pyenv
 PYTHON_PIP_VERSION_SPECIFIER ?= >=21.1.2
 PYTHON_SETUPTOOLS_VERSION_SPECIFIER ?= >=57.0.0
-PYTHON_WHEEL_VERSION_SPECIFIER ?= >=0.36.2
 PYTHON_PIP_TOOLS_VERSION_SPECIFIER ?= >=7.0.0
 PYTHON_PIP_TOOLS_SRC_FILES ?= requirements.in
 
@@ -14,10 +13,6 @@ python-pip-install: ## Install Pip
 .PHONY: python-setuptools-install
 python-setuptools-install: ## Install Setuptools
 	$(PYTHON_PIP) install 'setuptools$(PYTHON_SETUPTOOLS_VERSION_SPECIFIER)'
-
-.PHONY: python-wheel-install
-python-wheel-install: ## Install Wheel
-	$(PYTHON_PIP) install 'wheel$(PYTHON_WHEEL_VERSION_SPECIFIER)'
 
 .PHONY: python-deps-compile
 python-deps-compile: $(patsubst %,python-deps-compile-%,$(PYTHON_PIP_TOOLS_SRC_FILES))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@
 [build-system]
 requires = [
   "setuptools==80.9.0",
-  "wheel==0.45.1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
From [Wheel's documentation](https://github.com/pypa/wheel/blob/fc8cb416/README.rst):

> ## Historical note
>
> This project used to contain the implementation of the [setuptools](https://pypi.org/project/setuptools/)
> `bdist_wheel` command, but as of setuptools v70.1, it no longer needs
> `wheel` installed for that to work. Thus, you should install this
> **only** if you intend to use the `wheel` command line tool!