### PR TITLE
deps: Install Python package `setuptools`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -167,4 +167,6 @@ zipp==3.21.0
 pip==23.3
     # via pip-tools
 setuptools==80.9.0
-    # via pip-tools
+    # via
+    #   -c requirements.txt
+    #   pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,5 @@
 
 # Note: To install a package from a Git VCS repository, see the following example:
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
+
+setuptools==80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@
 #
 #    pip-compile --allow-unsafe --strip-extras requirements.in
 #
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==80.9.0
+    # via -r requirements.in


### PR DESCRIPTION
> Easily download, build, install, upgrade, and uninstall Python packages

- [Web Site](https://setuptools.pypa.io/)
- [VCS Repository](https://github.com/pypa/setuptools.git)
- [Documentation](https://setuptools.pypa.io/)
- [Software Repository](https://pypi.org/project/setuptools/)

**Note**: This package is already installed as a transitive dependency, but it is also a direct dependency (e.g. `setup.py` imports `setuptools`), and direct dependencies should be in `requirements.in` (and `requirements.txt`).