### PR TITLE
Update EditorConfig Checker configuration to fix deprecations

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -2,7 +2,7 @@
   "Verbose": false,
   "Debug": false,
   "IgnoreDefaults": false,
-  "SpacesAftertabs": false,
+  "SpacesAfterTabs": false,
   "NoColor": false,
   "Exclude": [],
   "AllowedContentTypes": [],


### PR DESCRIPTION
- Rename file `.ecrc` to `.editorconfig-checker.json`.
- Replace configuration key `SpacesAftertabs` with `SpacesAfterTabs`.

Ref: https://app.shortcut.com/cordada/story/15640 [sc-15640]