### PR TITLE
deps: Install Python package `pip`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -165,7 +165,9 @@ zipp==3.21.0
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
-    # via pip-tools
+    # via
+    #   -c requirements.txt
+    #   pip-tools
 setuptools==80.9.0
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,5 @@
 # Note: To install a package from a Git VCS repository, see the following example:
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
 
+pip==23.3
 setuptools==80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,7 @@
 #
 
 # The following packages are considered to be unsafe in a requirements file:
+pip==23.3
+    # via -r requirements.in
 setuptools==80.9.0
     # via -r requirements.in


### PR DESCRIPTION
> The PyPA recommended tool for installing Python packages.

- [Web Site](https://pip.pypa.io/)
- [VCS Repository](https://github.com/pypa/pip.git)
- [Documentation](https://pip.pypa.io/)
- [Software Repository](https://pypi.org/project/pip/)

**Note**: This package is already installed as a transitive dependency.