### PR TITLE
Do not install `setuptools` using Make tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ PYTHON_PIP_VERSION_SPECIFIER = $(shell \
 	grep -E '^pip==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
 	| head -n 1 | sed 's/^pip//' \
 )
-PYTHON_SETUPTOOLS_VERSION_SPECIFIER = $(shell \
-	grep -E '^setuptools==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
-	| head -n 1 | sed 's/^setuptools//' \
-)
 PYTHON_VIRTUALENV_DIR = lib-pe-sunat.pyenv
 PYTHON_PIP_TOOLS_VERSION_SPECIFIER = $(shell \
 	grep -E '^pip-tools==.+' --no-filename --only-matching --no-messages -- requirements{,-dev}.{txt,in} \
@@ -89,7 +85,7 @@ install-dev: ## Install for development
 	$(PYTHON_PIP) check
 
 .PHONY: install-deps
-install-deps: python-pip-install python-setuptools-install
+install-deps: python-pip-install
 install-deps: ## Install dependencies
 	$(PYTHON_PIP) install -r requirements.txt
 	$(PYTHON_PIP) check

--- a/make/python.mk
+++ b/make/python.mk
@@ -2,17 +2,12 @@ PYTHON ?= python3
 PYTHON_PIP ?= $(PYTHON) -m pip
 PYTHON_VIRTUALENV_DIR ?= pyenv
 PYTHON_PIP_VERSION_SPECIFIER ?= >=21.1.2
-PYTHON_SETUPTOOLS_VERSION_SPECIFIER ?= >=57.0.0
 PYTHON_PIP_TOOLS_VERSION_SPECIFIER ?= >=7.0.0
 PYTHON_PIP_TOOLS_SRC_FILES ?= requirements.in
 
 .PHONY: python-pip-install
 python-pip-install: ## Install Pip
 	$(PYTHON_PIP) install 'pip$(PYTHON_PIP_VERSION_SPECIFIER)'
-
-.PHONY: python-setuptools-install
-python-setuptools-install: ## Install Setuptools
-	$(PYTHON_PIP) install 'setuptools$(PYTHON_SETUPTOOLS_VERSION_SPECIFIER)'
 
 .PHONY: python-deps-compile
 python-deps-compile: $(patsubst %,python-deps-compile-%,$(PYTHON_PIP_TOOLS_SRC_FILES))


### PR DESCRIPTION
Since commit d7be9ff624108e01f342df4c551acab1a5e4b93b, `setuptools` is installed and managed through dependency manifests (`requirements.*`), so we can delete Make task `python-setuptools-install`.