### PR TITLE
deps: Update `pip` from 23.3 to 24.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -164,7 +164,7 @@ zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==24.2
     # via
     #   -c requirements.txt
     #   pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -5,5 +5,5 @@
 # Note: To install a package from a Git VCS repository, see the following example:
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
 
-pip==23.3
+pip==24.2
 setuptools==80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==24.2
     # via -r requirements.in
 setuptools==80.9.0
     # via -r requirements.in


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/pip/24.2/)
- [Release Notes](https://pip.pypa.io/en/stable/news/#v24-2)
- [Changelog](https://github.com/pypa/pip/blob/24.2/NEWS.rst#242-2024-07-28)
- [Commits](https://github.com/pypa/pip/compare/23.3...24.2)