### PR TITLE
Fix Python package license metadata deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ description = """\
   Python library for Superintendencia Nacional de Aduanas y de Administración Tributaria (SUNAT) \
   of Peru."""
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
- `license` must be a valid SPDX license expression.
- License classifiers are deprecated and have been superseded by license expressions (see [PEP 639](https://peps.python.org/pep-0639/)).
- Add `license-files` to specify the license file. (Not related to the deprecations.)