### PR TITLE
deps: Update `pip-tools` from 7.4.1 to 7.5.3

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -10,7 +10,7 @@ flake8-formatter-junit-xml==0.0.6
 flake8==7.3.0
 isort==6.1.0
 mypy==1.19.1
-pip-tools==7.4.1
+pip-tools==7.5.3
 tox==4.30.3
 twine==6.2.0
 unittest-xml-reporting==3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -102,7 +102,7 @@ pathspec==0.9.0
     # via
     #   black
     #   mypy
-pip-tools==7.4.1
+pip-tools==7.5.3
     # via -r requirements-dev.in
 platformdirs==4.4.0
     # via


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/pip-tools/7.5.3/)
- [Release Notes](https://github.com/jazzband/pip-tools/releases/tag/v7.5.3)
- [Changelog](https://github.com/jazzband/pip-tools/blob/v7.5.3/CHANGELOG.md#v753)
- [Commits](https://github.com/jazzband/pip-tools/compare/7.4.1...v7.5.3)

Related Dependabot commits and pull requests:

- https://github.com/dependabot/dependabot-core/commit/e015cd60fd31fc44806d4acf67d916084d01ef88
- https://github.com/dependabot/dependabot-core/pull/12770