### PR TITLE
deps: Update `pip` from 24.2 to 26.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -182,7 +182,7 @@ zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
+pip==26.0.1
     # via
     #   -c requirements.txt
     #   pip-tools

--- a/requirements.in
+++ b/requirements.in
@@ -5,5 +5,5 @@
 # Note: To install a package from a Git VCS repository, see the following example:
 #   git+https://github.com/example/example.git@example-vcs-ref#egg=example-pkg[foo,bar]==1.42.3
 
-pip==24.2
+pip==26.0.1
 setuptools==80.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
+pip==26.0.1
     # via -r requirements.in
 setuptools==80.9.0
     # via -r requirements.in


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/pip/26.0.1/)
- ~~[Release Notes]()~~
- [Changelog](https://github.com/pypa/pip/blob/26.0.1/NEWS.rst#2601-2026-02-04)
- [Commits](https://github.com/pypa/pip/compare/24.2...26.0.1)