### PR TITLE
chore(deps): Restrict python version to <3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 name = "pe-sunat"
 # version = ""
 dependencies = []
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.11"
 authors = [
   {name = "Cordada SpA", email = "no-reply@cordada.com"},
 ]


### PR DESCRIPTION
- restrict python version to <3.11 to prevent not tested versions being selected at release

Ref: https://app.shortcut.com/cordada/story/20072/